### PR TITLE
Made god hunters an actual threat

### DIFF
--- a/Code/Effects.cs
+++ b/Code/Effects.cs
@@ -4,11 +4,12 @@ VERSION: 1.0.0
 */
 using System.Collections.Generic;
 using ReflectionUtility;
+using UnityEngine;
 
 namespace GodsAndPantheons
 {
     class Effects
-    { 
+    {
         public static void init()
         {
 
@@ -48,18 +49,18 @@ namespace GodsAndPantheons
             localizeStatus(darkGodEra.id, "Nights_Prevail", darkGodEra.description); // Localizes the status effect
             AssetManager.status.add(darkGodEra);
 
-	        StatusEffect GodOfGodsEra = new StatusEffect();
+            StatusEffect GodOfGodsEra = new StatusEffect();
             GodOfGodsEra.id = "God_Of_All";
             GodOfGodsEra.duration = 7000f;
             GodOfGodsEra.base_stats[S.mod_armor] = 0.5f;
-	        GodOfGodsEra.base_stats[S.mod_damage] = 0.5f;
-	        GodOfGodsEra.base_stats[S.range] += 10;
+            GodOfGodsEra.base_stats[S.mod_damage] = 0.5f;
+            GodOfGodsEra.base_stats[S.range] += 10;
             GodOfGodsEra.base_stats[S.mod_health] = 0.5f;
             GodOfGodsEra.base_stats[S.speed] += 70;
             GodOfGodsEra.base_stats[S.knockback_reduction] += 0.5f;
             GodOfGodsEra.base_stats[S.mod_crit] = 0.5f;
             GodOfGodsEra.base_stats[S.attack_speed] += 40f;
-	        GodOfGodsEra.base_stats[S.scale] += 0.075f;
+            GodOfGodsEra.base_stats[S.scale] += 0.075f;
             GodOfGodsEra.base_stats[S.dodge] += 40f;
             GodOfGodsEra.path_icon = "ui/icons/GodofGods";
             GodOfGodsEra.description = "Now i have become death, destroyer of worlds";
@@ -163,6 +164,19 @@ namespace GodsAndPantheons
             localizeStatus(lichgodera.id, "Sorrow Prevails", lichgodera.description); // Localizes the status effect
             AssetManager.status.add(lichgodera);
 
+            StatusEffect Invisible = new StatusEffect();
+            Invisible.duration = 7000f;
+            Invisible.id = "Invisible";
+            Invisible.path_icon = "Actors/Godhunter/walk_0";
+            Invisible.name = "Invisible";
+            Invisible.description = "you cant see me";
+            Invisible.base_stats[S.speed] += 60;
+            Invisible.base_stats[S.knockback_reduction] += 2f;
+            Invisible.action_interval = 0.5f;
+            Invisible.action = new WorldAction(InvisibleEffect);
+            localizeStatus(Invisible.id, "Invisible", Invisible.description); // Localizes the status effect
+            AssetManager.status.add(Invisible);
+
             StatusEffect chaosgodsera = new StatusEffect();
             chaosgodsera.duration = 7000f;
             chaosgodsera.id = "Chaos Prevails";
@@ -193,7 +207,7 @@ namespace GodsAndPantheons
             warGodsCry.path_icon = "ui/icons/warGod";
             warGodsCry.description = "A Cry Of Anger and Rage";
             warGodsCry.name = "WarGodsCry";
-            
+
             localizeStatus(warGodsCry.id, "WarGodsCry", warGodsCry.description); // Localizes the status effect
             AssetManager.status.add(warGodsCry);
 
@@ -220,10 +234,19 @@ namespace GodsAndPantheons
         }
 
         public static void localizeStatus(string id, string name, string description)
-      	{
-      		Dictionary<string, string> localizedText = Reflection.GetField(LocalizedTextManager.instance.GetType(), LocalizedTextManager.instance, "localizedText") as Dictionary<string, string>;
+        {
+            Dictionary<string, string> localizedText = Reflection.GetField(LocalizedTextManager.instance.GetType(), LocalizedTextManager.instance, "localizedText") as Dictionary<string, string>;
             localizedText.Add(name, id);
             localizedText.Add(description, description);
+        }
+        public static bool InvisibleEffect(BaseSimObject pTarget, WorldTile pTile)
+        {
+            Color mycolor = pTarget.GetComponent<SpriteRenderer>().sharedMaterial.color;
+            if(mycolor.a != 0.4)
+            {
+                pTarget.GetComponent<SpriteRenderer>().sharedMaterial.color = new Color(mycolor.r, mycolor.g, mycolor.b, 0.4f);
+            }
+            return true;
         }
     }
 

--- a/Code/Effects.cs
+++ b/Code/Effects.cs
@@ -241,10 +241,10 @@ namespace GodsAndPantheons
         }
         public static bool InvisibleEffect(BaseSimObject pTarget, WorldTile pTile)
         {
-            Color mycolor = pTarget.GetComponent<SpriteRenderer>().sharedMaterial.color;
+            Color mycolor = pTarget.GetComponent<SpriteRenderer>().color;
             if(mycolor.a != 0.4)
             {
-                pTarget.GetComponent<SpriteRenderer>().sharedMaterial.color = new Color(mycolor.r, mycolor.g, mycolor.b, 0.4f);
+                pTarget.GetComponent<SpriteRenderer>().color = new Color(mycolor.r, mycolor.g, mycolor.b, 0.4f);
             }
             return true;
         }

--- a/Code/Invasions.cs
+++ b/Code/Invasions.cs
@@ -2,7 +2,6 @@ namespace GodsAndPantheons
 {
     class Invasions
     {
-        public static Actor nextInvader;
         public static void init()
         {
             DisasterAsset hunterInvasion = new DisasterAsset();

--- a/Code/Invasions.cs
+++ b/Code/Invasions.cs
@@ -11,12 +11,12 @@ namespace GodsAndPantheons
             hunterInvasion.chance = 0.9f;
             hunterInvasion.min_world_cities = 9;
             hunterInvasion.max_existing_units = 2;
-            hunterInvasion.world_log = "A God Hunter Comes From Another World Seeking Gods";
+            hunterInvasion.world_log = "A group of God Hunters have Come From Another World Seeking Gods";
             hunterInvasion.world_log_icon = "godKiller";
             hunterInvasion.min_world_population = 0;
             hunterInvasion.spawn_asset_unit = "GodHunter";
-            hunterInvasion.units_min = 1;
-            hunterInvasion.units_max = 3;
+            hunterInvasion.units_min = 2;
+            hunterInvasion.units_max = 5;
             hunterInvasion.ages_forbid.Add(S.age_hope);
             hunterInvasion.action = new DisasterAction(AssetManager.disasters.simpleUnitAssetSpawnUsingIslands);
             AssetManager.disasters.add(hunterInvasion);

--- a/Code/NewUI.cs
+++ b/Code/NewUI.cs
@@ -1,4 +1,4 @@
-awwusing System.Globalization;
+using System.Globalization;
 using NCMS.Utils;
 using UnityEngine;
 using UnityEngine.Events;

--- a/Code/Patches.cs
+++ b/Code/Patches.cs
@@ -5,6 +5,18 @@ using System.Collections.Generic;
 //Harmony Patches
 namespace GodsAndPantheons
 {
+    [HarmonyPatch(typeof(BaseSimObject), "canAttackTarget")]
+    public class DontAttack
+    {
+        static bool Prefix(BaseSimObject __instance, BaseSimObject pTarget)
+        {
+            if (pTarget.hasStatus("Invisible") || __instance.hasStatus("Invisible"))
+            {
+                return false;
+            }
+            return true;
+        }
+    }
     [HarmonyPatch(typeof(ActorBase), "clearAttackTarget")]
     public class KEEPATTACKING
     {

--- a/Code/Patches.cs
+++ b/Code/Patches.cs
@@ -10,8 +10,18 @@ namespace GodsAndPantheons
     {
         static bool Prefix(BaseSimObject __instance, BaseSimObject pTarget)
         {
-            if (pTarget.hasStatus("Invisible") || __instance.hasStatus("Invisible"))
+            if (pTarget.hasStatus("Invisible"))
             {
+                return false;
+            }
+            if (__instance.hasStatus("Invisible")){
+                if (pTarget.isActor())
+                {
+                    if (Traits.IsGod(pTarget.a))
+                    {
+                        return true;
+                    }
+                }
                 return false;
             }
             return true;
@@ -44,6 +54,11 @@ namespace GodsAndPantheons
             if (Traits.IsGod(pDeadUnit))
             {
                 __instance.addTrait("God Killer");
+            }
+            if (__instance.hasTrait("God Hunter"))
+            {
+                Traits.SuperRegeneration(__instance, 90, 50);
+                __instance.data.set("invisiblecooldown", 5);
             }
         }
     }

--- a/Code/Patches.cs
+++ b/Code/Patches.cs
@@ -58,7 +58,6 @@ namespace GodsAndPantheons
             if (__instance.hasTrait("God Hunter"))
             {
                 Traits.SuperRegeneration(__instance, 90, 50);
-                __instance.data.set("invisiblecooldown", 5);
             }
         }
     }

--- a/Code/TraitTools.cs
+++ b/Code/TraitTools.cs
@@ -186,6 +186,14 @@ namespace GodsAndPantheons
             }
             return false;
         }
+        public static bool SuperRegeneration(BaseSimObject pTarget, float chance, float percent)
+        {
+            if (Toolbox.randomChance(chance / 100))
+            {
+                pTarget.a.restoreHealth((int)(pTarget.a.getMaxHealth() * (percent / 100)));
+            }
+            return true;
+        }
         //returns the raw chance
         public static float GetChance(string ID, string Chance, float Default = 0) => Main.savedSettings.Chances.ContainsKey(ID) ? Main.savedSettings.Chances[ID].ContainsKey(Chance) ? Main.savedSettings.Chances[ID][Chance].active ? float.Parse(Main.savedSettings.Chances[ID][Chance].value) : 0 : Default : Default;
         //returns 2 if the trait's era is one, 1 if it is not, Default if the trait is not found

--- a/Code/Traits.cs
+++ b/Code/Traits.cs
@@ -16,7 +16,6 @@ namespace GodsAndPantheons
     //Contains the traits and their abilities & Stats
     partial class Traits
     {
-
         public static Dictionary<string, Dictionary<string, float>> TraitStats = new Dictionary<string, Dictionary<string, float>>()
         {
             {"God Of Chaos", new Dictionary<string, float>(){
@@ -535,26 +534,40 @@ namespace GodsAndPantheons
                 {
                     if (IsGod(a.a))
                     {
-                        if (TeleportNearActor(pTarget.a, a, 27, false, true)) SuperRegeneration(pTarget, pTile);
+                        if (TeleportNearActor(pTarget.a, a, 27, false, true)) SuperRegeneration(pTarget, 25, 5);
                     }
                 }
-                else if (Toolbox.randomChance(0.5f))
+                else
                 {
-                    if (TeleportNearActor(pTarget.a, Toolbox.getClosestActor(FindGods(pTarget.a, true), pTarget.currentTile), 54, false, true)) SuperRegeneration(pTarget, pTile);
+                    Actor godtohunt = Toolbox.getClosestActor(FindGods(pTarget.a, true), pTarget.currentTile);
+                    float distancetogod = Vector2.Distance(godtohunt.currentPosition, pTarget.currentPosition);
+                    if (pTarget.hasStatus("Invisible"))
+                    {
+                        if (distancetogod < 5f)
+                        {
+                            pTarget.GetComponent<SpriteRenderer>().sharedMaterial = LibraryMaterials.instance.mat_world_object;
+                            pTarget.finishStatusEffect("Invisible");
+                            pTarget.a.setAttackTarget(godtohunt);
+                        }
+                        else
+                        {
+                            pTarget.a.setTileTarget(godtohunt.currentTile);
+                        }
+                    }
+                    else if(distancetogod > 5f)
+                    {
+                        pTarget.addStatusEffect("Invisible");
+                    }
+                    if (Toolbox.randomChance(0.5f))
+                    {
+                        if (TeleportNearActor(pTarget.a, godtohunt, 54, false, true)) SuperRegeneration(pTarget, 50, 25);
+                    }
                 }
-
             }
             return true;
         }
         
-        public static bool SuperRegeneration(BaseSimObject pTarget, WorldTile pTile)
-        {
-            if (Toolbox.randomChance(0.1f))
-            {
-                pTarget.a.restoreHealth((int)(pTarget.a.getMaxHealth() * 0.05f));
-            }
-           return true;
-        }
+        public static bool SuperRegeneration(BaseSimObject pTarget, WorldTile pTile) => SuperRegeneration(pTarget, 10, 5);
         //god of gods attack
         public static bool GodOfGodsAttack(BaseSimObject pSelf, BaseSimObject pTarget, WorldTile pTile)
         {

--- a/Code/Traits.cs
+++ b/Code/Traits.cs
@@ -464,6 +464,7 @@ namespace GodsAndPantheons
             godHunter.action_special_effect = (WorldAction)Delegate.Combine(godHunter.action_special_effect, new WorldAction(GodWeaponManager.godGiveWeapon));
             godHunter.action_special_effect = (WorldAction)Delegate.Combine(godHunter.action_special_effect, new WorldAction(AutoTrait));
             godHunter.action_special_effect = (WorldAction)Delegate.Combine(godHunter.action_special_effect, new WorldAction(ChaseGod));
+            godHunter.action_attack_target = new AttackAction(GodHunterAttack);
             godHunter.group_id = TraitGroup.special;
             godHunter.can_be_given = false;
             AddTrait(godHunter, "He will stop at NOTHING to kill a god");
@@ -505,6 +506,16 @@ namespace GodsAndPantheons
             AddTrait(FailedGod, "his Genes were recessive");
             pb = new PowerLibrary();
         }
+
+        private static bool GodHunterAttack(BaseSimObject pSelf, BaseSimObject pTarget, WorldTile pTile)
+        {
+            if (pSelf.isActor())
+            {
+                pSelf.a.data.set("invisiblecooldown", 5);
+            }
+            return true;
+        }
+
         //to make summoned ones only live for like 30 secounds
         public static bool SummonedBeing(BaseSimObject pTarget, WorldTile pTile)
         {

--- a/Code/Traits.cs
+++ b/Code/Traits.cs
@@ -464,7 +464,8 @@ namespace GodsAndPantheons
             godHunter.action_special_effect = (WorldAction)Delegate.Combine(godHunter.action_special_effect, new WorldAction(GodWeaponManager.godGiveWeapon));
             godHunter.action_special_effect = (WorldAction)Delegate.Combine(godHunter.action_special_effect, new WorldAction(AutoTrait));
             godHunter.action_special_effect = (WorldAction)Delegate.Combine(godHunter.action_special_effect, new WorldAction(ChaseGod));
-            godHunter.group_id = "GodTraits";
+            godHunter.group_id = TraitGroup.special;
+            godHunter.can_be_given = false;
             AddTrait(godHunter, "He will stop at NOTHING to kill a god");
 
             //my traits
@@ -532,6 +533,11 @@ namespace GodsAndPantheons
                 BaseSimObject? a = Reflection.GetField(typeof(ActorBase), pTarget, "attackTarget") as BaseSimObject;
                 if (a != null)
                 {
+                    if (pTarget.hasStatus("Invisible"))
+                    {
+                        pTarget.finishStatusEffect("Invisible");
+                        pTarget.GetComponent<SpriteRenderer>().color = new Color(1, 1, 1, 1);
+                    }
                     if (IsGod(a.a))
                     {
                         if (TeleportNearActor(pTarget.a, a, 27, false, true)) SuperRegeneration(pTarget, 25, 5);
@@ -539,29 +545,19 @@ namespace GodsAndPantheons
                 }
                 else
                 {
-                    Actor godtohunt = Toolbox.getClosestActor(FindGods(pTarget.a, true), pTarget.currentTile);
-                    float distancetogod = Vector2.Distance(godtohunt.currentPosition, pTarget.currentPosition);
-                    if (pTarget.hasStatus("Invisible"))
-                    {
-                        if (distancetogod < 5f)
-                        {
-                            pTarget.GetComponent<SpriteRenderer>().sharedMaterial = LibraryMaterials.instance.mat_world_object;
-                            pTarget.finishStatusEffect("Invisible");
-                            pTarget.a.setAttackTarget(godtohunt);
-                        }
-                        else
-                        {
-                            pTarget.a.setTileTarget(godtohunt.currentTile);
-                        }
-                    }
-                    else if(distancetogod > 5f)
-                    {
-                        pTarget.addStatusEffect("Invisible");
-                    }
-                    if (Toolbox.randomChance(0.5f))
-                    {
-                        if (TeleportNearActor(pTarget.a, godtohunt, 54, false, true)) SuperRegeneration(pTarget, 50, 25);
-                    }
+                  pTarget.a.data.get("invisiblecooldown", out int invisiblecooldown);
+                  if (invisiblecooldown == 0)
+                  {
+                      pTarget.addStatusEffect("Invisible");
+                  }
+                  else
+                  {
+                      pTarget.a.data.set("invisiblecooldown", invisiblecooldown - 1);
+                  }
+                  if (Toolbox.randomChance(0.5f))
+                  {
+                      if (TeleportNearActor(pTarget.a, Toolbox.getClosestActor(FindGods(pTarget.a, true), pTarget.currentTile), 54, false, true)) SuperRegeneration(pTarget, 50, 25);
+                  }
                 }
             }
             return true;


### PR DESCRIPTION
-god hunters can now spawn in groups
-god hunters can now have the invisible effect, they will become invisible normaly and nobody can see them when they are invisible, when a godhunter finds a god, he will remove the invisible effect and attack the god
-god hunters heal when they kill someone

because of this god hunters can kill even the strongest of gods when they are alone, gods are only safe if they are with others