### PR TITLE
God hunters now have a custom beh!

### DIFF
--- a/Code/Effects.cs
+++ b/Code/Effects.cs
@@ -244,10 +244,17 @@ namespace GodsAndPantheons
         public static bool InvisibleEffect(BaseSimObject pTarget, WorldTile pTile)
         {
             Color mycolor = pTarget.GetComponent<SpriteRenderer>().color;
-            if(mycolor.a != 0.4)
+            if (pTarget.activeStatus_dict["Invisible"]._end_time > World.world.getCurWorldTime())
             {
-                pTarget.a.restoreHealth(pTarget.a.getMaxHealth());
-                pTarget.GetComponent<SpriteRenderer>().color = new Color(mycolor.r, mycolor.g, mycolor.b, 0.4f);
+                if (mycolor.a != 0.4)
+                {
+                    pTarget.a.restoreHealth(pTarget.a.getMaxHealth());
+                    pTarget.GetComponent<SpriteRenderer>().color = new Color(mycolor.r, mycolor.g, mycolor.b, 0.4f);
+                }
+            }
+            else
+            {
+                pTarget.GetComponent<SpriteRenderer>().color = new Color(mycolor.r, mycolor.g, mycolor.b, 1);
             }
             return true;
         }

--- a/Code/Effects.cs
+++ b/Code/Effects.cs
@@ -244,18 +244,11 @@ namespace GodsAndPantheons
         public static bool InvisibleEffect(BaseSimObject pTarget, WorldTile pTile)
         {
             Color mycolor = pTarget.GetComponent<SpriteRenderer>().color;
-            if (pTarget.activeStatus_dict["Invisible"]._end_time > World.world.getCurWorldTime())
-            {
                 if (mycolor.a != 0.4)
                 {
                     pTarget.a.restoreHealth(pTarget.a.getMaxHealth());
                     pTarget.GetComponent<SpriteRenderer>().color = new Color(mycolor.r, mycolor.g, mycolor.b, 0.4f);
                 }
-            }
-            else
-            {
-                pTarget.GetComponent<SpriteRenderer>().color = new Color(mycolor.r, mycolor.g, mycolor.b, 1);
-            }
             return true;
         }
     }

--- a/Code/GodHunterBeh.cs
+++ b/Code/GodHunterBeh.cs
@@ -54,6 +54,8 @@ namespace GodsAndPantheons
             if (Vector2.Distance(tiletoecapeto.pos, pActor.currentPosition) < 5)
             {
                 pActor.data.set("invisiblecooldown", 0);
+                pActor.data.removeInt("oldx");
+                pActor.data.removeInt("oldy");
             }
             pActor.beh_tile_target = tiletoecapeto;
             return BehResult.Continue;

--- a/Code/GodHunterBeh.cs
+++ b/Code/GodHunterBeh.cs
@@ -35,7 +35,7 @@ namespace GodsAndPantheons
 
         public override BehResult execute(Actor pActor)
         {
-            if(!(!pActor.hasStatus("Invisible") && pActor.data.health < pActor.getMaxHealth() * (pActor.hasStatus("powerup") ? 0.5 : 0.25)))
+            if(!(!pActor.hasStatus("Invisible") && pActor.data.health < pActor.getMaxHealth() * (pActor.hasStatus("powerup") ? 0.5 : 0.25)) ||  !pActor.currentTile.region.isTypeGround())
             {
                 return BehResult.Continue;
             }

--- a/Code/GodHunterBeh.cs
+++ b/Code/GodHunterBeh.cs
@@ -56,7 +56,7 @@ namespace GodsAndPantheons
             }
             if (Vector2.Distance(tiletoecapeto.pos, pActor.currentPosition) < 5)
             {
-                pActor.addStatusEffect("Invisible");
+                pActor.data.set("invisiblecooldown", 0);
                 pActor.data.removeInt("oldx");
                 pActor.data.removeInt("oldy");
             }
@@ -96,7 +96,6 @@ namespace GodsAndPantheons
             }
             else
             {
-                WorldTile oldtile = pActor.currentTile;
                 if (Traits.TeleportNearActor(pActor, GodToHunt, 44))
                 {
                     Traits.SuperRegeneration(pActor, 50, 25);

--- a/Code/GodHunterBeh.cs
+++ b/Code/GodHunterBeh.cs
@@ -1,9 +1,6 @@
 ﻿using ai.behaviours;
-using Discord;
 using System.Collections.Generic;
-using System.Threading;
 using UnityEngine;
-using static UnityEngine.GraphicsBuffer;
 
 namespace GodsAndPantheons
 {

--- a/Code/GodHunterBeh.cs
+++ b/Code/GodHunterBeh.cs
@@ -54,8 +54,6 @@ namespace GodsAndPantheons
             if (Vector2.Distance(tiletoecapeto.pos, pActor.currentPosition) < 5)
             {
                 pActor.data.set("invisiblecooldown", 0);
-                pActor.data.removeInt("oldx");
-                pActor.data.removeInt("oldy");
             }
             pActor.beh_tile_target = tiletoecapeto;
             return BehResult.Continue;

--- a/Code/GodHunterBeh.cs
+++ b/Code/GodHunterBeh.cs
@@ -1,0 +1,157 @@
+﻿using ai.behaviours;
+using Discord;
+using System.Collections.Generic;
+using System.Threading;
+using UnityEngine;
+using static UnityEngine.GraphicsBuffer;
+
+namespace GodsAndPantheons
+{
+    internal class GodHunterBeh
+    {
+        public static void init()
+        {
+            BehaviourTaskActor GodHunt = new BehaviourTaskActor();
+            GodHunt.id = "GodHunt";
+            GodHunt.addBeh(new HuntGods());
+            GodHunt.addBeh(new BehAttackGod());
+            GodHunt.addBeh(new escape());
+            GodHunt.addBeh(new BehGoToTileTarget());
+            AssetManager.tasks_actor.add(GodHunt);
+            ActorJob GodHunterob = new ActorJob
+            {
+                id = "GodHunter",
+            };
+            GodHunterob.addTask("GodHunt");
+            AssetManager.job_actor.add(GodHunterob);
+        }
+    }
+    public class escape : BehaviourActionActor
+    {
+        public override void create()
+        {
+            base.create();
+        }
+
+        public override BehResult execute(Actor pActor)
+        {
+            if(!(!pActor.hasStatus("Invisible") && pActor.data.health < pActor.getMaxHealth() * (pActor.hasStatus("powerup") ? 0.5 : 0.25)))
+            {
+                return BehResult.Continue;
+            }
+            pActor.clearAttackTarget();
+            pActor.data.get("oldx", out int oldx, -1);
+            pActor.data.get("oldy", out int oldy);
+            if(oldx == -1)
+            {
+                WorldTile tiletoescapeto = null;
+                for (int i =0; i < 15; i++) {
+                    tiletoescapeto = pActor.currentTile.region.island.getRandomTile();
+                    if(Vector2.Distance(tiletoescapeto.pos, pActor.currentPosition) > 20)
+                    {
+                        break;
+                    }
+                }
+                pActor.data.set("oldx", tiletoescapeto.x);
+                pActor.data.set("oldy", tiletoescapeto.y);
+                pActor.data.get("oldx", out oldx);
+                pActor.data.get("oldy", out oldy);
+            }
+            WorldTile tiletoecapeto = World.world.GetTileSimple(oldx, oldy);
+            if (Vector2.Distance(tiletoecapeto.pos, pActor.currentPosition) < 5)
+            {
+                pActor.addStatusEffect("Invisible");
+                pActor.data.removeInt("oldx");
+                pActor.data.removeInt("oldy");
+            }
+            pActor.beh_tile_target = tiletoecapeto;
+            return BehResult.Continue;
+        }
+    }
+    public class HuntGods : BehaviourActionActor
+    {
+        public static Actor GodToHunt;
+        public override BehResult execute(Actor pActor)
+        {
+            GodToHunt = Toolbox.getClosestActor(Traits.FindGods(pActor), pActor.currentTile);
+            if (GodToHunt == null || !pActor.hasStatus("Invisible"))
+            {
+                getrandomtile(ref pActor);
+                return BehResult.Continue;
+            }
+            if (GodToHunt.currentTile.isSameIsland(pActor.currentTile))
+            {
+                pActor.beh_tile_target = GodToHunt.currentTile;
+            }
+            else
+            {
+                WorldTile oldtile = pActor.currentTile;
+                if (Traits.TeleportNearActor(pActor, GodToHunt, 44))
+                {
+                    Traits.SuperRegeneration(pActor, 50, 25);
+                    pActor.beh_tile_target = GodToHunt.currentTile;
+                }
+            }
+            return BehResult.Continue;
+        }
+        public static void getrandomtile(ref Actor pActor)
+        {
+            MapRegion mapRegion = pActor.currentTile.region;
+            if (Toolbox.randomChance(0.65f) && mapRegion.tiles.Count > 0)
+            {
+               pActor.beh_tile_target  = mapRegion.tiles.GetRandom();
+            }
+            if (mapRegion.neighbours.Count > 0 && Toolbox.randomBool())
+            {
+                mapRegion = mapRegion.neighbours.GetRandom();
+            }
+            if (mapRegion.tiles.Count > 0)
+            {
+                pActor.beh_tile_target = mapRegion.tiles.GetRandom();
+            }
+        }
+    }
+
+    public class BehAttackGod : BehaviourActionActor
+    {
+        public override BehResult execute(Actor pActor)
+        {
+            if(HuntGods.GodToHunt == null)
+            {
+                return BehResult.Continue;
+            }
+            if(Vector2.Distance(HuntGods.GodToHunt.currentPosition, pActor.currentPosition) > 8)
+            {
+                return BehResult.Continue;
+            }
+            World.world.getObjectsInChunks(pActor.currentTile, 4, MapObjectType.Actor);
+            if (getalliesofactor(World.world.temp_map_objects, HuntGods.GodToHunt) > 7)
+            {
+                return BehResult.Continue;
+            }
+            pActor.finishStatusEffect("Invisible");
+            pActor.GetComponent<SpriteRenderer>().color = new Color(1, 1, 1, 1);
+            pActor.setAttackTarget(HuntGods.GodToHunt);
+            return BehResult.Continue;
+        }
+        static int getalliesofactor(List<BaseSimObject> actors, BaseSimObject actor)
+        {
+            int count = 0;
+            foreach (BaseSimObject a in actors)
+            {
+                if (a.kingdom == actor.kingdom)
+                {
+                    count++;
+                }
+            }
+            return count;
+        }
+    }
+    public class RUNWHILEYOURSTILLALIVE : BehaviourActorCondition
+    {
+        public override bool check(Actor pActor)
+        {
+            return !pActor.hasStatus("Invisible") && pActor.data.health < pActor.getMaxHealth() * (pActor.hasStatus("powerup") ? 0.5 : 0.25);
+        }
+    }
+}

--- a/Code/GodHunterBeh.cs
+++ b/Code/GodHunterBeh.cs
@@ -140,7 +140,6 @@ namespace GodsAndPantheons
                 return BehResult.Continue;
             }
             pActor.finishStatusEffect("Invisible");
-            pActor.GetComponent<SpriteRenderer>().color = new Color(1, 1, 1, 1);
             pActor.setAttackTarget(HuntGods.GodToHunt);
             return BehResult.Continue;
         }

--- a/Code/GodHunterBeh.cs
+++ b/Code/GodHunterBeh.cs
@@ -81,28 +81,28 @@ namespace GodsAndPantheons
     }
     public class HuntGods : BehaviourActionActor
     {
-        public static Actor GodToHunt;
+        public static Actor? GodToHunt;
         public override BehResult execute(Actor pActor)
         {
             GodToHunt = Toolbox.getClosestActor(Traits.FindGods(pActor), pActor.currentTile);
             if (GodToHunt == null || !pActor.hasStatus("Invisible") || !Main.savedSettings.HunterAssasins)
             {
+                GodToHunt = null;
                 getrandomtile(ref pActor);
                 return BehResult.Continue;
             }
             if (GodToHunt.currentTile.isSameIsland(pActor.currentTile))
             {
                 pActor.beh_tile_target = GodToHunt.currentTile;
+                return BehResult.Continue;
             }
-            else
+            if (Traits.TeleportNearActor(pActor, GodToHunt, 44))
             {
-                if (Traits.TeleportNearActor(pActor, GodToHunt, 44))
-                {
-                    Traits.SuperRegeneration(pActor, 50, 25);
-                    pActor.beh_tile_target = GodToHunt.currentTile;
-                }
+               Traits.SuperRegeneration(pActor, 50, 25);
+               pActor.beh_tile_target = GodToHunt.currentTile;
+               return BehResult.Continue;
             }
-            return BehResult.Continue;
+            return BehResult.RestartTask;
         }
         public static void getrandomtile(ref Actor pActor)
         {

--- a/Code/GodHunterBeh.cs
+++ b/Code/GodHunterBeh.cs
@@ -42,22 +42,18 @@ namespace GodsAndPantheons
             pActor.clearAttackTarget();
             pActor.data.get("oldx", out int oldx, -1);
             pActor.data.get("oldy", out int oldy);
-            if(oldx == -1)
+            WorldTile tiletoecapeto;
+            if (oldx == -1)
             {
-                WorldTile tiletoescapeto = null;
-                for (int i =0; i < 15; i++) {
-                    tiletoescapeto = pActor.currentTile.region.island.getRandomTile();
-                    if(Vector2.Distance(tiletoescapeto.pos, pActor.currentPosition) > 20)
-                    {
-                        break;
-                    }
-                }
-                pActor.data.set("oldx", tiletoescapeto.x);
-                pActor.data.set("oldy", tiletoescapeto.y);
+                GetTileToEscapeToo(ref pActor);
                 pActor.data.get("oldx", out oldx);
                 pActor.data.get("oldy", out oldy);
             }
-            WorldTile tiletoecapeto = World.world.GetTileSimple(oldx, oldy);
+            tiletoecapeto = World.world.GetTileSimple(oldx, oldy);
+            if (!tiletoecapeto.isSameIsland(pActor.currentTile))
+            {
+                tiletoecapeto = GetTileToEscapeToo(ref pActor);
+            }
             if (Vector2.Distance(tiletoecapeto.pos, pActor.currentPosition) < 5)
             {
                 pActor.addStatusEffect("Invisible");
@@ -67,6 +63,21 @@ namespace GodsAndPantheons
             pActor.beh_tile_target = tiletoecapeto;
             return BehResult.Continue;
         }
+        WorldTile GetTileToEscapeToo(ref Actor pActor)
+        {
+            WorldTile tiletoescapeto = null;
+            for (int i = 0; i < 15; i++)
+            {
+                tiletoescapeto = pActor.currentTile.region.island.getRandomTile();
+                if (Vector2.Distance(tiletoescapeto.pos, pActor.currentPosition) > 20)
+                {
+                    break;
+                }
+            }
+            pActor.data.set("oldx", tiletoescapeto.x);
+            pActor.data.set("oldy", tiletoescapeto.y);
+            return tiletoescapeto;
+        }
     }
     public class HuntGods : BehaviourActionActor
     {
@@ -74,7 +85,7 @@ namespace GodsAndPantheons
         public override BehResult execute(Actor pActor)
         {
             GodToHunt = Toolbox.getClosestActor(Traits.FindGods(pActor), pActor.currentTile);
-            if (GodToHunt == null || !pActor.hasStatus("Invisible"))
+            if (GodToHunt == null || !pActor.hasStatus("Invisible") || !Main.savedSettings.HunterAssasins)
             {
                 getrandomtile(ref pActor);
                 return BehResult.Continue;

--- a/Code/GodWeaponManager.cs
+++ b/Code/GodWeaponManager.cs
@@ -136,7 +136,6 @@ public static class GodWeaponManager
                 ItemData godHuntersScythe = new ItemData();
                 godHuntersScythe.id = "GodHuntersScythe";
                 godHuntersScythe.material = "base";
-                pTarget.addStatusEffect("Invisible");
                 pTarget.a.equipment.getSlot(EquipmentType.Weapon).setItem(godHuntersScythe);
                 pTarget.a.setStatsDirty();
             }

--- a/Code/Invasions.cs
+++ b/Code/Invasions.cs
@@ -20,7 +20,6 @@ namespace GodsAndPantheons
             hunterInvasion.action = new DisasterAction(AssetManager.disasters.simpleUnitAssetSpawnUsingIslands);
             AssetManager.disasters.add(hunterInvasion);
         }
-
     }
 
 }

--- a/Code/Main.cs
+++ b/Code/Main.cs
@@ -44,6 +44,7 @@ namespace GodsAndPantheons
             NewTerraformOptions.init();
             NewEffects.init();
             Items.init();
+            GodHunterBeh.init();
             Units.init();
             Tab.init();
             Invasions.init();

--- a/Code/Patches.cs
+++ b/Code/Patches.cs
@@ -10,9 +10,16 @@ namespace GodsAndPantheons
     {
         static bool Prefix(BaseSimObject __instance, BaseSimObject pTarget)
         {
-            if (pTarget.hasStatus("Invisible") || __instance.hasStatus("Invisible"))
+            if (Main.savedSettings.HunterAssasins)
             {
-                return false;
+                if (pTarget.hasStatus("Invisible") || __instance.hasStatus("Invisible"))
+                {
+                    return false;
+                }
+                if (__instance.isActor() && __instance.a.hasTrait("God Hunter") && __instance.a.data.health < __instance.getMaxHealth() * (__instance.hasStatus("powerup") ? 0.5 : 0.25))
+                {
+                    return false;
+                }
             }
             return true;
         }

--- a/Code/Patches.cs
+++ b/Code/Patches.cs
@@ -2,6 +2,7 @@
 using HarmonyLib;
 using ReflectionUtility;
 using System.Collections.Generic;
+using UnityEngine;
 //Harmony Patches
 namespace GodsAndPantheons
 {
@@ -59,6 +60,31 @@ namespace GodsAndPantheons
                 Traits.SuperRegeneration(__instance, 100, isgod ? 30 : 5);
                 __instance.data.get("godskilled", out int godskilled);
                 __instance.data.set("godskilled", godskilled + (isgod ? 1 : 0));
+            }
+        }
+    }
+    [HarmonyPatch(typeof(StatusEffectData), "update")]
+    public class finishinvisibility
+    {
+        static void Postfix(StatusEffectData __instance)
+        {
+            if (__instance.finished && __instance.asset.id == "Invisible")
+            {
+                __instance._simObject.GetComponent<SpriteRenderer>().color = new Color(1, 1, 1, 1);
+            }
+        }
+    }
+    [HarmonyPatch(typeof(BaseSimObject), "finishStatusEffect")]
+    public class finishinvisibility2
+    {
+        static void Postfix(string pID, BaseSimObject __instance)
+        {
+            if (__instance.activeStatus_dict.ContainsKey(pID))
+            {
+                if(pID == "Invisible")
+                {
+                    __instance.GetComponent<SpriteRenderer>().color = new Color(1, 1, 1, 1);
+                }
             }
         }
     }

--- a/Code/Patches.cs
+++ b/Code/Patches.cs
@@ -79,6 +79,7 @@ namespace GodsAndPantheons
     {
         static void Postfix(string pID, BaseSimObject __instance)
         {
+            if(__instance.activeStatus_dict == null) { return; }
             if (__instance.activeStatus_dict.ContainsKey(pID))
             {
                 if(pID == "Invisible")

--- a/Code/Patches.cs
+++ b/Code/Patches.cs
@@ -10,61 +10,11 @@ namespace GodsAndPantheons
     {
         static bool Prefix(BaseSimObject __instance, BaseSimObject pTarget)
         {
-            if (pTarget.hasStatus("Invisible"))
+            if (pTarget.hasStatus("Invisible") || __instance.hasStatus("Invisible"))
             {
                 return false;
             }
-            if (__instance.isActor() && __instance.a.hasTrait("God Hunter"))
-            {
-                if (pTarget.isBuilding())
-                {
-                    foreach (Actor god in Traits.FindGods(__instance.a))
-                    {
-                       Building? building = Reflection.GetField(typeof(Actor), god, "insideBuilding") as Building;
-                       if (building != null)
-                       {
-                          if (building == pTarget.b)
-                          {
-                             World.world.getObjectsInChunks(pTarget.currentTile, 4, MapObjectType.Actor);
-                             if (getalliesofactor(World.world.temp_map_objects, pTarget) < 6 || !__instance.hasStatus("Invisible"))
-                             {
-                                return true;
-                             }
-                          }
-                       }
-                    }
-                    return false;
-                }
-                if (__instance.hasStatus("Invisible"))
-                {
-                    if (pTarget.isActor())
-                    {
-                        if (Traits.IsGod(pTarget.a))
-                        {
-                            __instance.a.data.set("GodTarget", pTarget.a.data.id);
-                            World.world.getObjectsInChunks(pTarget.currentTile, 4, MapObjectType.Actor);
-                            if (getalliesofactor(World.world.temp_map_objects, pTarget) < 7)
-                            {
-                                return true;
-                            }
-                        }
-                    }
-                    return false;
-                }
-            }
             return true;
-        }
-        static int getalliesofactor(List<BaseSimObject> actors, BaseSimObject actor)
-        {
-            int count = 0;
-            foreach(BaseSimObject a in actors)
-            {
-                if(a.kingdom == actor.kingdom)
-                {
-                    count++;
-                }
-            }
-            return count;
         }
     }
     [HarmonyPatch(typeof(ActorBase), "clearAttackTarget")]
@@ -79,7 +29,7 @@ namespace GodsAndPantheons
                 {
                     if (a.isActor())
                     {
-                        if (Traits.IsGod(a.a) && a.isAlive() && !__instance.hasStatus("Invisible")) { return false; }
+                        if (Traits.IsGod(a.a) && a.isAlive() && !__instance.hasStatus("Invisible") && __instance.data.health >= __instance.getMaxHealth() * (__instance.hasStatus("powerup") ? 0.5 : 0.25)) { return false; }
                     }
                 }
             }

--- a/Code/TraitTools.cs
+++ b/Code/TraitTools.cs
@@ -8,7 +8,7 @@ namespace GodsAndPantheons
     //contains tools for working with the traits
     partial class Traits
     {
-        static PowerLibrary pb = new PowerLibrary();
+        public static PowerLibrary pb = new PowerLibrary();
         //returns null if unable to find master
         public static Actor FindMaster(Actor summoned)
         {
@@ -135,7 +135,7 @@ namespace GodsAndPantheons
             return temp_gods_list;
         }
         //returns true if teleported
-        public static bool TeleportNearActor(Actor Actor, BaseSimObject Target, int distance, bool AllTiles = false, bool MustBeFar = false, byte Attempts = 20)
+        public static bool TeleportNearActor(Actor Actor, BaseSimObject Target, int distance, bool AllTiles = false, bool MustBeFar = true, byte Attempts = 20)
         {
             if (Target != null)
             {

--- a/Code/Traits.cs
+++ b/Code/Traits.cs
@@ -543,7 +543,7 @@ namespace GodsAndPantheons
                 pTarget.a.data.set("invisiblecooldown", invisiblecooldown > 0 ? invisiblecooldown - 1 : 0);
                 if (invisiblecooldown == 0)
                 {
-                   pTarget.addStatusEffect("Invisible");
+                   pTarget.addStatusEffect("Invisible", 11);
                 }
             }
             return true;

--- a/Code/Traits.cs
+++ b/Code/Traits.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using HarmonyLib;
 using Amazon.Runtime.Internal.Transform;
 using static UnityEngine.GraphicsBuffer;
+using System.Threading;
 
 
 namespace GodsAndPantheons
@@ -462,7 +463,7 @@ namespace GodsAndPantheons
             godHunter.action_special_effect = new WorldAction(SuperRegeneration);
             godHunter.action_special_effect = (WorldAction)Delegate.Combine(godHunter.action_special_effect, new WorldAction(GodWeaponManager.godGiveWeapon));
             godHunter.action_special_effect = (WorldAction)Delegate.Combine(godHunter.action_special_effect, new WorldAction(AutoTrait));
-            godHunter.action_special_effect = (WorldAction)Delegate.Combine(godHunter.action_special_effect, new WorldAction(ChaseGod));
+            godHunter.action_special_effect = (WorldAction)Delegate.Combine(godHunter.action_special_effect, new WorldAction(InvisibleCooldown));
             godHunter.action_attack_target = new AttackAction(GodHunterAttack);
             godHunter.group_id = TraitGroup.special;
             godHunter.can_be_given = false;
@@ -508,11 +509,6 @@ namespace GodsAndPantheons
         {
             if (pSelf.isActor())
             {
-                if (pSelf.hasStatus("Invisible"))
-                {
-                    pSelf.finishStatusEffect("Invisible");
-                    pSelf.GetComponent<SpriteRenderer>().color = new Color(1, 1, 1, 1);
-                }
                 pSelf.a.data.set("invisiblecooldown", 10);
             }
             return true;
@@ -539,50 +535,15 @@ namespace GodsAndPantheons
             return true;
         }
         //if god is too far away the god hunter will teleport to them
-        public static bool ChaseGod(BaseSimObject pTarget, WorldTile pTile)
+        public static bool InvisibleCooldown(BaseSimObject pTarget, WorldTile pTile)
         {
             if (pTarget.isActor() && Main.savedSettings.HunterAssasins)
             {
                 pTarget.a.data.get("invisiblecooldown", out int invisiblecooldown);
                 pTarget.a.data.set("invisiblecooldown", invisiblecooldown > 0 ? invisiblecooldown - 1 : 0);
-                pTarget.a.data.get("GodTarget", out string godtarget);
-                if(invisiblecooldown == 0)
+                if (invisiblecooldown == 0)
                 {
-                    pTarget.addStatusEffect("Invisible");
-                }
-                if (!pTarget.hasStatus("Invisible") && pTarget.a.data.health < pTarget.a.getMaxHealth() * (pTarget.hasStatus("powerup") ? 0.5 : 0.25))
-                {
-                    World.world.getObjectsInChunks(pTarget.currentTile, 4, MapObjectType.Actor);
-                    if (World.world.temp_map_objects.Count < 5)
-                    {
-                        ActionLibrary.teleportRandom(null, pTarget, null);
-                        pTarget.addStatusEffect("Invisible");
-                        pTarget.a.data.set("invisiblecooldown", 14);
-                    }
-                    return false;
-                }
-                if (godtarget != null)
-                {
-                    Actor godtohunt = World.world.units.get(godtarget);
-                    if (godtohunt != default(Actor))
-                    {
-                        if (godtohunt.currentTile.isSameIsland(pTarget.currentTile))
-                        {
-                            TeleportNearActor(pTarget.a, godtohunt, 5, false, true);
-                        }
-                        else
-                        {
-                            if (TeleportNearActor(pTarget.a, godtohunt, 27, false, true)) SuperRegeneration(pTarget, 25, 5);
-                        }
-                    }
-                    else
-                    {
-                        pTarget.a.data.removeString("GodTarget");
-                    }
-                }
-                else if (Toolbox.randomChance(0.5f))
-                {
-                    if (TeleportNearActor(pTarget.a, Toolbox.getClosestActor(FindGods(pTarget.a, true), pTarget.currentTile), 40, false, true)) SuperRegeneration(pTarget, 50, 25);
+                   pTarget.addStatusEffect("Invisible");
                 }
             }
             return true;
@@ -1098,6 +1059,7 @@ namespace GodsAndPantheons
                }
                if (autoTraited)
                {
+                  pTarget.setStatsDirty();
                   pTarget.a.restoreHealth(pTarget.a.getMaxHealth());
                }
             }

--- a/Code/Units.cs
+++ b/Code/Units.cs
@@ -35,7 +35,7 @@ namespace GodsAndPantheons
             var godHunter = AssetManager.actor_library.clone("GodHunter", "_mob");
             godHunter.nameLocale = "GodHunter";
             godHunter.nameTemplate = "alien_name";
-            godHunter.job = "move_mob";
+            godHunter.job = "GodHunter";
             godHunter.race = "GodHunters";
             godHunter.defaultAttack = "GodHuntersScythe";
             godHunter.kingdom = "GodHunters";


### PR DESCRIPTION
instead of doing all that stuff in the godhunter trait, i gave the unit its own beh! it has 3 stages:

-1: find gods, a god hunter will scan for gods in a world, once he finds one, instead of teleporting he will walk all the way to them, if the godhunter is on a dfferent island then he will teleport

-2 attack them / break down the building their in, a god hunter will only do this when the god's allies are not nearby

-3 get the hell out, if a god hunter health is less than 25% or 50% if he killed a god, he will try to run, if he is far enough he will become invisible

when the hunter Assassins setting is turned off god hunters will just wander around but will still go invisible and flee

Also, do you think demigods should be considered gods? if they are then god hunter scythes would deal 5x more damage, and they are weaker then all the other gods..