### PR TITLE
The Diplomacy Update

### DIFF
--- a/Code/Buttons.cs
+++ b/Code/Buttons.cs
@@ -70,10 +70,22 @@ namespace GodsAndPantheons
                     tab.transform,
                     WindowManager.windows["KnowledgeGodWindow"].openWindow
               );
+            PowerButton butto = PowerButtons.CreateButton(
+                    "ToggleDiplomacyModifiers",
+                    Resources.Load<Sprite>("ui/Icons/iconDiplomacy"),
+                    "Diplomacy Modifiers",
+                    "if enabled, kingdoms will change their opinions on other kingdoms based on if their king's are gods",
+                    new Vector2(388, -18),
+                    ButtonType.Toggle,
+                    tab.transform,
+                    ToggleDiplomacy
+              );
+            if (Main.savedSettings.DiplomacyChanges)
+                PowerButtons.ToggleButton(butto.name);
             PowerButton button = PowerButtons.CreateButton(
                     "ToggleDeathEras",
                     Resources.Load<Sprite>("ui/Icons/ages/iconAgeHope"),
-                    "Option modifier",
+                    "Death Eras",
                     "should deaths change the era?",
                     new Vector2(388, 18),
                     ButtonType.Toggle,
@@ -85,7 +97,7 @@ namespace GodsAndPantheons
             PowerButton button2 = PowerButtons.CreateButton(
                     "HunterAssassins",
                     Resources.Load<Sprite>("ui/Icons/godKiller"),
-                    "option modifier",
+                    "Hunter Assassins",
                     "if enabled, god hunters will become assassins and will hunt down gods",
                     new Vector2(530, 18),
                     ButtonType.Toggle,
@@ -97,7 +109,7 @@ namespace GodsAndPantheons
             PowerButton button3 = PowerButtons.CreateButton(
                     "DevineMiracles",
                     Resources.Load<Sprite>("ui/Icons/iconNightchild"),
-                    "option modifier",
+                    "Devine Miracles",
                     "allows for a very, very rare chance that a mortal in a kingdom will become a god",
                     new Vector2(424, 18),
                     ButtonType.Toggle,
@@ -109,7 +121,7 @@ namespace GodsAndPantheons
             PowerButton button4 = PowerButtons.CreateButton(
                     "GodKings",
                     Resources.Load<Sprite>("ui/Icons/iconKings"),
-                    "option modifier",
+                    "God Kings",
                     "if enabled, gods will always take higher priority when electing a new king",
                     new Vector2(424, -18),
                     ButtonType.Toggle,
@@ -121,7 +133,7 @@ namespace GodsAndPantheons
             PowerButton Button5 = PowerButtons.CreateButton(
                     "MakeSummonedOne",
                     Resources.Load<Sprite>("ui/Icons/iconBlessing"),
-                    "option modifier",
+                    "Spawn Summoned Ones",
                     "if enabled, if you were to spawn a creature on a tile that already has a creature on it, the new creature will be a summoned one of that creature, note that summoned ones have their own AI and only live for 60 or 120s (unless they are immortal)",
                     new Vector2(530, -18),
                     ButtonType.Toggle,
@@ -245,6 +257,11 @@ namespace GodsAndPantheons
         public static void ToggleSummmoned()
         {
             Main.savedSettings.MakeSummoned = !Main.savedSettings.MakeSummoned;
+            Main.saveSettings();
+        }
+        public static void ToggleDiplomacy()
+        {
+            Main.savedSettings.DiplomacyChanges = !Main.savedSettings.DiplomacyChanges;
             Main.saveSettings();
         }
     }

--- a/Code/Effects.cs
+++ b/Code/Effects.cs
@@ -26,7 +26,7 @@ namespace GodsAndPantheons
             sunGodEra.base_stats[S.dodge] += 80f;
             sunGodEra.path_icon = "ui/icons/lightGod";
             sunGodEra.description = "The World, Light up";
-            sunGodEra.name = "status_title_Lights_Prevail";
+            sunGodEra.name = "Lights Prevail";
             sunGodEra.action_interval = 2;
             sunGodEra.action = new WorldAction(Traits.SuperRegeneration);
             localizeStatus(sunGodEra.id, "Lights_Prevail", sunGodEra.description); // Localizes the status effect
@@ -44,7 +44,7 @@ namespace GodsAndPantheons
             darkGodEra.base_stats[S.attack_speed] += 8f;
             darkGodEra.path_icon = "ui/icons/godDark";
             darkGodEra.description = "The world, shrouded in my domain";
-            darkGodEra.name = "status_title_Nights_Prevail";
+            darkGodEra.name = "Nights Prevail";
             darkGodEra.action_interval = 2;
             darkGodEra.action = new WorldAction(Traits.SuperRegeneration);
             localizeStatus(darkGodEra.id, "Nights_Prevail", darkGodEra.description); // Localizes the status effect
@@ -85,7 +85,7 @@ namespace GodsAndPantheons
             knowledgeGodEra.base_stats[S.accuracy] += 20f;
             knowledgeGodEra.path_icon = "ui/icons/knowledgeGod";
             knowledgeGodEra.description = "The era of Knowledge has come to pass";
-            knowledgeGodEra.name = "status_title_Knowledge_Prevail";
+            knowledgeGodEra.name = "Knowledge Prevails";
             knowledgeGodEra.action_interval = 2;
             knowledgeGodEra.action = new WorldAction(Traits.SuperRegeneration);
             localizeStatus(knowledgeGodEra.id, "Knowledge_Prevail", knowledgeGodEra.description); // Localizes the status effect
@@ -95,14 +95,15 @@ namespace GodsAndPantheons
             starsGodEra.id = "Stars_Prevail";
             starsGodEra.duration = 7000f;
             starsGodEra.base_stats[S.health] += 500;
+            starsGodEra.base_stats[S.mod_health] = 0.5f;
             starsGodEra.base_stats[S.speed] += 30;
             starsGodEra.base_stats[S.knockback_reduction] += 0.8f;
-            starsGodEra.base_stats[S.knockback] += 1f;
+            starsGodEra.base_stats[S.armor] += 8f;
             starsGodEra.base_stats[S.mod_armor] += 0.2f;
             starsGodEra.base_stats[S.attack_speed] += 80f;
             starsGodEra.path_icon = "ui/icons/starsGod";
             starsGodEra.description = "The Age Of Stars is Apon Us";
-            starsGodEra.name = "status_title_Stars_Prevail";
+            starsGodEra.name = "Stars Prevail";
             starsGodEra.action_interval = 20;
             starsGodEra.action = new WorldAction(Traits.SuperRegeneration);
             localizeStatus(starsGodEra.id, "Stars_Prevail", starsGodEra.description); // Localizes the status effect
@@ -111,7 +112,7 @@ namespace GodsAndPantheons
             StatusEffect EarthGodEra = new StatusEffect();
             EarthGodEra.id = "Earth Prevails";
             EarthGodEra.duration = 7000f;
-            EarthGodEra.base_stats[S.mod_health] += 0.75f;
+            EarthGodEra.base_stats[S.mod_health] += 0.8f;
             EarthGodEra.base_stats[S.mod_speed] += 0.25f;
             EarthGodEra.base_stats[S.knockback_reduction] += 0.8f;
             EarthGodEra.base_stats[S.mod_damage] += 0.3f;
@@ -214,6 +215,8 @@ namespace GodsAndPantheons
             chaosgodsera.base_stats[S.knockback] += 2f;
             chaosgodsera.base_stats[S.attack_speed] += 8f;
             chaosgodsera.base_stats[S.damage] += 30f;
+            chaosgodsera.base_stats[S.armor] = 10f;
+            chaosgodsera.base_stats[S.mod_health] = 0.3f;
             chaosgodsera.action_interval = 2;
             chaosgodsera.action = new WorldAction(Traits.SuperRegeneration);
             AssetManager.status.add(chaosgodsera);
@@ -352,6 +355,9 @@ namespace GodsAndPantheons
             if (tile != null)
             {
                 MapAction.damageWorld(tile, 4, AssetManager.terraform.get("LesserCrabLaser"), pSelf);
+                ///ARMOR PENETRATING
+                pSelf.attackTarget.getHit(40, true, AttackType.Acid, pSelf, false, false);
+
                 if (pSelf.attackTarget.isActor())
                 {
                     Traits.PullActorTowardsPoint(pSelf.attackTarget.a, tile.pos, 0.5f);

--- a/Code/Items.cs
+++ b/Code/Items.cs
@@ -489,7 +489,7 @@ namespace GodsAndPantheons
         }
         static bool UnleashFire(BaseSimObject pSelf, BaseSimObject pTarget, WorldTile pTile)
         {
-            if (Toolbox.randomChance(GetEnhancedChance("God Of Chaos", "Power4%")))
+            if (Toolbox.randomChance(GetEnhancedChance("God Of Chaos", "BoneFire%")))
             {
                 Vector2Int pos = pTile.pos; // Position of the Ptile as a Vector 2
                 float pDist = Vector2.Distance(pTarget.currentPosition, pos); // the distance between the target and the pTile

--- a/Code/Main.cs
+++ b/Code/Main.cs
@@ -18,7 +18,7 @@ namespace GodsAndPantheons
     class Main : MonoBehaviour
     {
         
-        private const string correctSettingsVersion = "0.1.8";
+        private const string correctSettingsVersion = "0.1.9";
         public static SavedSettings savedSettings = new SavedSettings();
         internal static Dictionary<string, UnityEngine.Object> modsResources;
         public static Main instance;

--- a/Code/Main.cs
+++ b/Code/Main.cs
@@ -44,6 +44,7 @@ namespace GodsAndPantheons
             NewTerraformOptions.init();
             NewEffects.init();
             Items.init();
+            NewOpinions.init();
 
             //ai
             GodHunterBeh.init();

--- a/Code/NewOpinions.cs
+++ b/Code/NewOpinions.cs
@@ -51,7 +51,7 @@ namespace GodsAndPantheons
             {
                 if (World.world_era.id == TraitEras[trait].Key)
                 {
-                    return -20;
+                    return -80;
                 }
             }
             return 0;
@@ -76,7 +76,7 @@ namespace GodsAndPantheons
             {
                 if (enemyking.hasTrait(trait))
                 {
-                    return -30;
+                    return -120;
                 }
             }
             return 0;
@@ -105,7 +105,7 @@ namespace GodsAndPantheons
                     {
                         if (enemyking.hasTrait(enemytrait))
                         {
-                            return -15;
+                            return -60;
                         }
                     }
                 }
@@ -124,7 +124,7 @@ namespace GodsAndPantheons
             }
             if(IsGod(Self.king) && !IsGod(Target.king))
             {
-                return -5;
+                return -20;
             }
             return 0;
         }

--- a/Code/NewOpinions.cs
+++ b/Code/NewOpinions.cs
@@ -4,7 +4,7 @@ using System.Text;
 using static GodsAndPantheons.Traits;
 namespace GodsAndPantheons
 {
-    internal class NewOpinions
+    public class NewOpinions
     {
         public static void init()
         {

--- a/Code/NewOpinions.cs
+++ b/Code/NewOpinions.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using static GodsAndPantheons.Traits;
+namespace GodsAndPantheons
+{
+    internal class NewOpinions
+    {
+        public static void init()
+        {
+            OpinionAsset EnemyGods = new OpinionAsset();
+            EnemyGods.id = "Enemy_Gods";
+            EnemyGods.translation_key = "Enemy Gods";
+            EnemyGods.calc = EnemyGodKings;
+            AssetManager.opinion_library.add(EnemyGods);
+
+            OpinionAsset NoRespect = new OpinionAsset();
+            NoRespect.id = "No Respect";
+            NoRespect.translation_key = "The Other King Isnt A God!";
+            NoRespect.calc = NoRespectForKings;
+            AssetManager.opinion_library.add(NoRespect);
+
+            OpinionAsset ThereCanOnlyBeOne = new OpinionAsset();
+            ThereCanOnlyBeOne.id = "There Can Only Be One";
+            ThereCanOnlyBeOne.translation_key = "There Can Only Be One God!";
+            ThereCanOnlyBeOne.calc = ThereCanOnlyBeOneGod;
+            AssetManager.opinion_library.add(ThereCanOnlyBeOne);
+
+            OpinionAsset MyAgeHasBegun = new OpinionAsset();
+            MyAgeHasBegun.id = "My Age Has Begun";
+            MyAgeHasBegun.translation_key = "My Age Has Begun!";
+            MyAgeHasBegun.calc = MyAgeHasBegunn;
+            AssetManager.opinion_library.add(MyAgeHasBegun);
+        }
+        public static int MyAgeHasBegunn(Kingdom Self, Kingdom Target)
+        {
+            if (!Main.savedSettings.DiplomacyChanges)
+            {
+                return 0;
+            }
+            if(Self.king == null)
+            {
+                return 0;
+            }
+            Actor myking = Self.king;
+            if (!IsGod(myking))
+            {
+                return 0;
+            }
+            foreach(string trait in GetGodTraits(myking))
+            {
+                if (World.world_era.id == TraitEras[trait].Key)
+                {
+                    return -20;
+                }
+            }
+            return 0;
+        }
+        public static int ThereCanOnlyBeOneGod(Kingdom Self, Kingdom Target)
+        {
+            if (!Main.savedSettings.DiplomacyChanges)
+            {
+                return 0;
+            }
+            if (Self.king == null || Target.king == null)
+            {
+                return 0;
+            }
+            Actor myking = Self.king;
+            Actor enemyking = Target.king;
+            if (!IsGod(myking) || !IsGod(enemyking))
+            {
+                return 0;
+            }
+            foreach(string trait in GetGodTraits(myking))
+            {
+                if (enemyking.hasTrait(trait))
+                {
+                    return -30;
+                }
+            }
+            return 0;
+        }
+        public static int EnemyGodKings(Kingdom Self, Kingdom Target)
+        {
+            if (!Main.savedSettings.DiplomacyChanges)
+            {
+                return 0;
+            }
+            if (Self.king == null || Target.king == null)
+            {
+                return 0;
+            }
+            Actor myking = Self.king;
+            Actor enemyking = Target.king;
+            if (!IsGod(myking) || !IsGod(enemyking))
+            {
+                return 0;
+            }
+            foreach(string trait in GodEnemies.Keys)
+            {
+                if (myking.hasTrait(trait))
+                {
+                    foreach(string enemytrait in GodEnemies[trait])
+                    {
+                        if (enemyking.hasTrait(enemytrait))
+                        {
+                            return -15;
+                        }
+                    }
+                }
+            }
+            return 0;
+        }
+        public static int NoRespectForKings(Kingdom Self, Kingdom Target)
+        {
+            if (!Main.savedSettings.DiplomacyChanges)
+            {
+                return 0;
+            }
+            if (Self.king == null || Target.king == null)
+            {
+                return 0;
+            }
+            if(IsGod(Self.king) && !IsGod(Target.king))
+            {
+                return -5;
+            }
+            return 0;
+        }
+    }
+}

--- a/Code/NewTerraformOptions.cs
+++ b/Code/NewTerraformOptions.cs
@@ -35,7 +35,7 @@ namespace GodsAndPantheons
 
                 });
             TerraformOptions lessercrablaser = AssetManager.terraform.clone("LesserCrabLaser", "crab_laser");
-            lessercrablaser.damage = 160;
+            lessercrablaser.damage = 80;
             lessercrablaser.shake_intensity = 0.2f;
             lessercrablaser.applyForce = false;
             AssetManager.terraform.add(lessercrablaser);

--- a/Code/Patches.cs
+++ b/Code/Patches.cs
@@ -315,8 +315,6 @@ namespace GodsAndPantheons
             if (isgod)
             {
                 __instance.addTrait("God Killer");
-                __instance.data.get("godskilled", out int godskilled);
-                __instance.data.set("godskilled", godskilled + (isgod ? 1 : 0));
             }
             if(__instance.hasTrait("God Hunter"))
             {

--- a/Code/SavedSettings.cs
+++ b/Code/SavedSettings.cs
@@ -114,6 +114,7 @@ namespace GodsAndPantheons
         public bool DevineMiracles = false;
         public bool GodKings = true;
         public bool MakeSummoned = false;
+        public bool DiplomacyChanges = true;
     }
     [Serializable]
     public struct InputOption

--- a/Code/SavedSettings.cs
+++ b/Code/SavedSettings.cs
@@ -83,7 +83,7 @@ namespace GodsAndPantheons
               {
                   {"warGodsCry%", new InputOption{active = true, value = 1 }},
                   {"axeThrow%", new InputOption{active = true, value = 29 }},
-                  {"seedsOfWar%", new InputOption{active = true, value = 2 }},
+                  {"seedsOfWar%", new InputOption{active = true, value = 0.2f }},
                   {"God Of Warinherit%", new InputOption{active = true, value = 17 }}
               }
             },

--- a/Code/SavedSettings.cs
+++ b/Code/SavedSettings.cs
@@ -6,7 +6,7 @@ namespace GodsAndPantheons
     [Serializable]
     public class SavedSettings
     {
-        public string settingVersion = "0.1.8";
+        public string settingVersion = "0.1.9";
         //inheritance of the god traits is stored here
         //if it has a god parent and normal parent it will use the inherit for the chance of changing the stats of the demi god trait for the baby
         public Dictionary<string, Dictionary<string, InputOption>> Chances = new Dictionary<string, Dictionary<string, InputOption>>
@@ -14,11 +14,11 @@ namespace GodsAndPantheons
             {"KnowledgeGodWindow",
               new Dictionary<string, InputOption>
              {
-              {"KnowledgeGodPwr1%", new InputOption{active = true, value = 20 }},
-              {"KnowledgeGodPwr2%", new InputOption{active = true, value = 5 }},
-              {"KnowledgeGodPwr3%", new InputOption{active = true, value = 20 }},
-              {"KnowledgeGodPwr4%", new InputOption{active = true, value = 1 }},
-              {"KnowledgeGodPwr5%", new InputOption{active = true, value = 1.8f }},
+              {"UnleashFireAndAcid%", new InputOption{active = true, value = 20 }},
+              {"CastCurses%", new InputOption{active = true, value = 5 }},
+              {"Freeze%", new InputOption{active = true, value = 20 }},
+              {"CreateShield%", new InputOption{active = true, value = 1 }},
+              {"TeleprtTarget%", new InputOption{active = true, value = 1.8f }},
               {"SummonLightning%", new InputOption{active = true, value = 9 }},
               {"SummonMeteor%", new InputOption{active = true, value = 3 }},
               {"PagesOfKnowledge%", new InputOption{active = true, value = 3 }},
@@ -100,10 +100,10 @@ namespace GodsAndPantheons
             {"ChaosGodWindow",
                 new Dictionary<string, InputOption>
               {
-                  {"Power1%", new InputOption{active = true, value = 28 }},
-                  {"Power2%", new InputOption{active = true, value = 40 }},
-                  {"Power3%", new InputOption{active = true, value = 15 }},
-                  {"Power4%", new InputOption{active = true, value = 30 }},
+                  {"FireBall%", new InputOption{active = true, value = 28 }},
+                  {"UnleashChaos%", new InputOption{active = true, value = 40 }},
+                  {"ChaosBoulder%", new InputOption{active = true, value = 15 }},
+                  {"BoneFire%", new InputOption{active = true, value = 30 }},
                   {"WorldOfChaos%", new InputOption{active = true, value = 5 }},
                   {"God Of Chaosinherit%", new InputOption{active = true, value = 28 }}
               }

--- a/Code/Traits.cs
+++ b/Code/Traits.cs
@@ -651,14 +651,15 @@ namespace GodsAndPantheons
         {
             if (Toolbox.randomChance(GetEnhancedChance("God Of Chaos", "UnleashChaos%")))
             {
-                bool hasmadness = pSelf.a.hasTrait("madness");
                 World.world.getObjectsInChunks(pTile, 8, MapObjectType.Actor);
                 foreach(Actor a in World.world.temp_map_objects)
                 {
-                    a.addTrait("madness");
+                    if (a != pSelf.a)
+                    {
+                        a.addTrait("madness");
+                    }
                 }
                 pb.spawnCloudRage(pTile, null);
-                if (!hasmadness) { pSelf.a.removeTrait("madness"); }
             }
             return true;
         }

--- a/Code/Traits.cs
+++ b/Code/Traits.cs
@@ -382,6 +382,17 @@ namespace GodsAndPantheons
         };
         #endregion
 
+        #region God Relations
+        public static Dictionary<string, List<string>> GodEnemies = new Dictionary<string, List<string>>()
+        {
+            {"God Of light", new List<string>(){ "God Of the Stars", "God Of the Night" } },
+            { "God Of the Stars", new List<string>(){ "God Of light" } },
+            { "God Of the Night", new List<string>(){ "God Of light" } },
+            { "God Of Chaos", new List<string>(){ "God Of Knowledge" } },
+            { "God Of War", new List<string>(){ "God Of Knowledge" } },
+            { "God Of Knowledge", new List<string>(){ "God Of Chaos", "God Of War" } }
+        };
+        #endregion
         public static void init()
         {
 

--- a/Code/Traits.cs
+++ b/Code/Traits.cs
@@ -625,7 +625,7 @@ namespace GodsAndPantheons
         }
         public static bool ChaosBall(BaseSimObject pSelf, BaseSimObject pTarget, WorldTile pTile)
         {
-            if (Toolbox.randomChance(GetEnhancedChance("God Of Chaos", "Power1%")))
+            if (Toolbox.randomChance(GetEnhancedChance("God Of Chaos", "FireBall%")))
             {
                 Vector2Int pos = pTile.pos; // Position of the Ptile as a Vector 2
                 float pDist = Vector2.Distance(pTarget.currentPosition, pos); // the distance between the target and the pTile
@@ -638,7 +638,7 @@ namespace GodsAndPantheons
 
         public static bool UnleachChaos(BaseSimObject pSelf, BaseSimObject pTarget, WorldTile pTile)
         {
-            if (Toolbox.randomChance(GetEnhancedChance("God Of Chaos", "Power2%")))
+            if (Toolbox.randomChance(GetEnhancedChance("God Of Chaos", "UnleashChaos%")))
             {
                 bool hasmadness = pSelf.a.hasTrait("madness");
                 World.world.getObjectsInChunks(pTile, 8, MapObjectType.Actor);
@@ -654,7 +654,7 @@ namespace GodsAndPantheons
 
         public static bool ChaosBoulder(BaseSimObject pSelf, BaseSimObject pTarget, WorldTile pTile)
         {
-            if (Toolbox.randomChance(GetEnhancedChance("God Of Chaos", "Power3%")))
+            if (Toolbox.randomChance(GetEnhancedChance("God Of Chaos", "ChaosBoulder%")))
             {
                 pb.spawnBoulder(pTarget.currentTile, null);
             }
@@ -669,27 +669,23 @@ namespace GodsAndPantheons
         #region KnowledgeGodsAttack
         public static bool CreateElements(BaseSimObject pSelf, BaseSimObject pTarget, WorldTile pTile)
         {
-            if (Toolbox.randomChance(GetEnhancedChance("God Of Knowledge", "KnowledgeGodPwr1%") / 100))
+            if (Toolbox.randomChance(GetEnhancedChance("God Of Knowledge", "UnleashFireAndAcid%") / 100))
             {
                 // randomly spawns a flash of fire or acid on the tile 
                 MapBox.instance.dropManager.spawn(pTile, "fire", 5f, -1f);
                 MapBox.instance.dropManager.spawn(pTile, "acid", 5f, -1f);
                 MapBox.instance.dropManager.spawn(pTile, "fire", 5f, -1f); // Drops fire from distance 5 with scale of one at current tile
             }
-            if (Toolbox.randomChance(GetEnhancedChance("God Of Knowledge", "KnowledgeGodPwr3%")))
+            if (Toolbox.randomChance(GetEnhancedChance("God Of Knowledge", "Freeze%")))
             {
                 ActionLibrary.addFrozenEffectOnTarget(null, pTarget, null); // freezezz the target
-            }
-            if (Toolbox.randomChance(GetEnhancedChance("God Of Knowledge", "SummonLightning%")))
-            {
-                ActionLibrary.castLightning(null, pTarget, null); // Casts Lightning on the target
             }
             return true;
         }
 
         public static bool trydefendself(BaseSimObject pSelf, BaseSimObject pTarget, WorldTile pTile)
         {
-            if (Toolbox.randomChance(GetEnhancedChance("God Of Knowledge", "KnowledgeGodPwr4%")))
+            if (Toolbox.randomChance(GetEnhancedChance("God Of Knowledge", "CreateShield%")))
             {
                 pSelf.addStatusEffect("shield", 10);
             }
@@ -697,11 +693,11 @@ namespace GodsAndPantheons
             {
                 return false;
             }
-            if (Toolbox.randomChance(GetEnhancedChance("God Of Knowledge", "KnowledgeGodPwr5%")))
+            if (Toolbox.randomChance(GetEnhancedChance("God Of Knowledge", "TeleprtTarget%")))
             {
                 ActionLibrary.teleportRandom(null, pTarget, null); // flee
             }
-            if (Toolbox.randomChance(GetEnhancedChance("God Of Knowledge", "KnowledgeGodPwr2%")))
+            if (Toolbox.randomChance(GetEnhancedChance("God Of Knowledge", "CastCurses%")))
             {
                 ActionLibrary.castCurses(null, pTarget, null); // casts curses
                 ((Actor)pSelf).removeTrait("cursed");
@@ -1335,7 +1331,6 @@ namespace GodsAndPantheons
                 }
                 if (Toolbox.randomChance(GetEnhancedChance("God Of the Earth", "buildWorld%")))
                 {
-
                     buildMountain(pTile);
                 }
 

--- a/Code/Traits.cs
+++ b/Code/Traits.cs
@@ -1299,7 +1299,10 @@ namespace GodsAndPantheons
 
         public static bool warGodSeeds(BaseSimObject pTarget, WorldTile pTile)
         {
-
+            if (!World.world.worldLaws.world_law_diplomacy.boolVal)
+            {
+                return false;
+            }
             if (pTarget.a != null)
             {
 

--- a/Code/TraitsGroups.cs
+++ b/Code/TraitsGroups.cs
@@ -15,8 +15,6 @@ namespace GodsAndPantheons
             MTtraits.color = Color.black;
             AssetManager.trait_groups.add(MTtraits);
             addTraitGroupToLocalizedLibrary(MTtraits.id, "Godly Traits");
- 
- 
         }
         private static void addTraitGroupToLocalizedLibrary(string id, string name)
         {


### PR DESCRIPTION
-Ive Made saved settings less Vague
-Because of an oversight, the fire god's chaos laser wont actually do damage, it is now fixed

### The Diplomacy Update

ive created a new saved setting, diplomacy modifiers, if this is enabled, the relations between kingdoms will change based on their kings.

If a kingdoms king is a god, and the other kingdom's king is a mortal, the kingdom will lose -20 respect

if both kingdom's king's are the same god for example: (one kingdom's king is the god of light and the other kingdom's king is also the god of light) then both kingdoms will lose -120, because there can only be One God! (of the same type)

If both kingdom's kings are different gods, then they can lose -60 respect for each other if they are enemy gods, here are the current ones:

god of light <---Hates----> the god of dark and the god of the stars

god of knowledge <--Hates--> the god of war and the god of chaos

And finally, if a kingdom's king is a god and the current era is his era, then the kingdom will lose -80 respect for all other kingdoms